### PR TITLE
Avoid including .babelrc in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ node_modules
 src
 test
 examples
+.babelrc


### PR DESCRIPTION
In one of our apps we found that Jest was failing because it was trying to preprocess the code in react-resize-detector because it has the .babelrc file published and we allow Jest to process code in node_modules because some internal dependencies are ES6 modules. 

We fixed it by ignoring the path in Jest configuration but a best practice, AFAIK, is to avoid publishing the .babelrc to npm, especially if you don't publish the source.