### PR TITLE
Fix unexpected scrollbars in Chrome on OS X

### DIFF
--- a/src/helpers/resizeDetectorStyles.js
+++ b/src/helpers/resizeDetectorStyles.js
@@ -4,7 +4,7 @@ export const parentStyle = {
   top: 0,
   right: 0,
   bottom: 0,
-  overflow: 'scroll',
+  overflow: 'hidden',
   zIndex: -1,
   visibility: 'hidden',
 };


### PR DESCRIPTION
Fixes #6 

(:heart: to everybody who investigated this and provided solutions!)

I'm not sure whether there was a specific reason why the overflow was set to 'scroll' before? Would this break anything in another browser/OS? 
