### PR TITLE
Added property to force observe one element in particular

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ render(<App />, document.getElementById('root'));
 
 (Bool) Do not trigger onResize when a component mounts. Default: `false`.
 
+#### resizableElementId
+
+(string) Id of the element we want to observe. If no one provided, parentElement of the component will be used. Default: ``.
+
 ## License
 
 MIT

--- a/lib/components/ResizeDetector.js
+++ b/lib/components/ResizeDetector.js
@@ -69,7 +69,11 @@ var ResizeDetector = function (_PureComponent) {
   _createClass(ResizeDetector, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      this.ro.observe(this.el.parentElement);
+      if (this.props.resizableObjectId !== '') {
+        this.ro.observe(document.getElementById(this.props.resizableObjectId));
+      } else {
+        this.ro.observe(this.el.parentElement);
+      }
     }
   }, {
     key: 'render',
@@ -95,6 +99,7 @@ ResizeDetector.propTypes = {
   handleWidth: _propTypes2.default.bool,
   handleHeight: _propTypes2.default.bool,
   skipOnMount: _propTypes2.default.bool,
+  resizableObjectId: _propTypes2.default.string,
   onResize: _propTypes2.default.func
 };
 
@@ -102,6 +107,7 @@ ResizeDetector.defaultProps = {
   handleWidth: false,
   handleHeight: false,
   skipOnMount: false,
+  resizableObjectId: '',
   onResize: function onResize(e) {
     return e;
   }

--- a/lib/components/ResizeDetector.js
+++ b/lib/components/ResizeDetector.js
@@ -69,8 +69,8 @@ var ResizeDetector = function (_PureComponent) {
   _createClass(ResizeDetector, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      if (this.props.resizableObjectId !== '') {
-        this.ro.observe(document.getElementById(this.props.resizableObjectId));
+      if (this.props.resizableElementId !== '') {
+        this.ro.observe(document.getElementById(this.props.resizableElementId));
       } else {
         this.ro.observe(this.el.parentElement);
       }
@@ -99,7 +99,7 @@ ResizeDetector.propTypes = {
   handleWidth: _propTypes2.default.bool,
   handleHeight: _propTypes2.default.bool,
   skipOnMount: _propTypes2.default.bool,
-  resizableObjectId: _propTypes2.default.string,
+  resizableElementId: _propTypes2.default.string,
   onResize: _propTypes2.default.func
 };
 
@@ -107,7 +107,7 @@ ResizeDetector.defaultProps = {
   handleWidth: false,
   handleHeight: false,
   skipOnMount: false,
-  resizableObjectId: '',
+  resizableElementId: '',
   onResize: function onResize(e) {
     return e;
   }

--- a/src/components/ResizeDetector.js
+++ b/src/components/ResizeDetector.js
@@ -35,7 +35,12 @@ export default class ResizeDetector extends PureComponent {
   }
 
   componentDidMount() {
-    this.ro.observe(this.el.parentElement);
+	  if (this.props.resizableObjectId !== '') {
+        this.ro.observe(document.getElementById(this.props.resizableObjectId));
+      }
+      else {
+        this.ro.observe(this.el.parentElement);
+      }
   }
 
   render() {
@@ -54,6 +59,7 @@ ResizeDetector.propTypes = {
   handleWidth: PropTypes.bool,
   handleHeight: PropTypes.bool,
   skipOnMount: PropTypes.bool,
+  resizableObjectId: PropTypes.string,
   onResize: PropTypes.func,
 };
 
@@ -61,5 +67,6 @@ ResizeDetector.defaultProps = {
   handleWidth: false,
   handleHeight: false,
   skipOnMount: false,
+  resizableObjectId: '',
   onResize: e => e,
 };

--- a/src/components/ResizeDetector.js
+++ b/src/components/ResizeDetector.js
@@ -35,12 +35,11 @@ export default class ResizeDetector extends PureComponent {
   }
 
   componentDidMount() {
-	  if (this.props.resizableObjectId !== '') {
-        this.ro.observe(document.getElementById(this.props.resizableObjectId));
-      }
-      else {
-        this.ro.observe(this.el.parentElement);
-      }
+    if (this.props.resizableObjectId !== '') {
+      this.ro.observe(document.getElementById(this.props.resizableObjectId));
+    } else {
+      this.ro.observe(this.el.parentElement);
+    }
   }
 
   render() {

--- a/src/components/ResizeDetector.js
+++ b/src/components/ResizeDetector.js
@@ -35,8 +35,8 @@ export default class ResizeDetector extends PureComponent {
   }
 
   componentDidMount() {
-    if (this.props.resizableObjectId !== '') {
-      this.ro.observe(document.getElementById(this.props.resizableObjectId));
+    if (this.props.resizableElementId !== '') {
+      this.ro.observe(document.getElementById(this.props.resizableElementId));
     } else {
       this.ro.observe(this.el.parentElement);
     }
@@ -58,7 +58,7 @@ ResizeDetector.propTypes = {
   handleWidth: PropTypes.bool,
   handleHeight: PropTypes.bool,
   skipOnMount: PropTypes.bool,
-  resizableObjectId: PropTypes.string,
+  resizableElementId: PropTypes.string,
   onResize: PropTypes.func,
 };
 
@@ -66,6 +66,6 @@ ResizeDetector.defaultProps = {
   handleWidth: false,
   handleHeight: false,
   skipOnMount: false,
-  resizableObjectId: '',
+  resizableElementId: '',
   onResize: e => e,
 };


### PR DESCRIPTION
In some situations, complex layouts, the resizer cannot be set as child of the desired element to be watched for resize. This new property allow coder to hard-code a element id instead of use the immediate parentElement of the component.