### PR TITLE
[issue-27], Add unobserve to componentWillUnmount

### DIFF
--- a/src/components/ResizeDetector.js
+++ b/src/components/ResizeDetector.js
@@ -37,6 +37,12 @@ export default class ResizeDetector extends PureComponent {
     this.ro.observe(resizableElement);
   }
 
+  componentWillUnmount() {
+    const { resizableElementId } = this.props;
+    const resizableElement = resizableElementId ? document.getElementById(resizableElementId) : this.el.parentElement;
+    this.ro.unobserve(resizableElement);
+  }
+
   createResizeObserver = (entries) => {
     const {
       handleWidth, handleHeight, onResize,


### PR DESCRIPTION
This will resolve this issue: https://github.com/maslianok/react-resize-detector/issues/27

You can see others are working around this by using a mounted flag: https://github.com/recharts/recharts/blob/master/src/component/ResponsiveContainer.js#L71