### PR TITLE
fix: HOC not importing React Component

### DIFF
--- a/src/hoc/withResizeDetector.js
+++ b/src/hoc/withResizeDetector.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import ResizeDetector from 'components/ResizeDetector';
 
 const withResizeDetector = (


### PR DESCRIPTION
Importing the missing '{Component} from React' within the HOC implementation 