### PR TITLE
Remove some development files from NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,7 @@ src
 test
 examples
 .babelrc
+yarn.lock
+.eslintignore
+.eslintrc
+.travis.yml


### PR DESCRIPTION
The yarn.lock file is 152 kB, this causes the size of the package to be quite large.