### PR TITLE
useResizeDetector Type updates for better React Typescript compatibility (Addresses #108)

### DIFF
--- a/src/ResizeDetector.tsx
+++ b/src/ResizeDetector.tsx
@@ -17,6 +17,10 @@ export interface ReactResizeDetectorDimensions {
   width?: number;
 }
 
+interface ChildFunctionProps extends ReactResizeDetectorDimensions {
+  targetRef?: RefObject<HTMLElement>
+}
+
 export interface Props {
   /**
    * Function that will be invoked with observable element's width and height.
@@ -98,7 +102,7 @@ export interface ComponentsProps extends Props {
 
   render?: (props: ReactResizeDetectorDimensions) => ReactNode;
 
-  children: ReactNode | ((width: number, height: number, targetRef) => ReactNode);
+  children: ReactNode | ((props: ChildFunctionProps) => ReactNode);
 }
 
 class ResizeDetector extends PureComponent<ComponentsProps, ReactResizeDetectorDimensions> {
@@ -299,7 +303,7 @@ class ResizeDetector extends PureComponent<ComponentsProps, ReactResizeDetectorD
       case 'renderProp':
         return render && render(childProps);
       case 'childFunction':
-        typedChildren = children as (props: { width?: number; height?: number; targetRef?: any }) => ReactNode;
+        typedChildren = children as (props: ChildFunctionProps) => ReactNode;
         return typedChildren(childProps);
       case 'child':
         // @TODO bug prone logic

--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -6,20 +6,20 @@ import { patchResizeHandler, isFunction, isSSR, patchResizeHandlerType } from '.
 import { Props, ReactResizeDetectorDimensions } from './ResizeDetector';
 
 type resizeHandlerType = MutableRefObject<null | patchResizeHandlerType>;
-interface returnType extends ReactResizeDetectorDimensions {
-  ref: MutableRefObject<undefined | Element>
+interface returnType<RefType> extends ReactResizeDetectorDimensions {
+  ref: MutableRefObject<null | RefType>
 }
 
-const createAsyncNotifier = (onResize, setSize) =>
+const createAsyncNotifier = (onResize: Props['onResize'], setSize: (size: ReactResizeDetectorDimensions) => void) =>
   rafSchd(({ width, height }) => {
-    if (isFunction(onResize)) {
+    if (onResize && isFunction(onResize)) {
       onResize(width, height);
     }
 
     setSize({ width, height });
   });
 
-function useResizeDetector(props: Props = {}): returnType {
+function useResizeDetector<RefType extends Element = Element>(props: Props = {}): returnType<RefType> {
   const {
     skipOnMount = false,
     refreshMode,
@@ -31,7 +31,7 @@ function useResizeDetector(props: Props = {}): returnType {
   } = props;
 
   const skipResize: MutableRefObject<null | boolean> = useRef(null);
-  const ref: MutableRefObject<undefined | Element> = useRef();
+  const ref: MutableRefObject<null | RefType> = useRef<RefType>(null);
   const resizeHandler: resizeHandlerType = useRef(null);
   const onResizeCallback = useRef(onResize);
 
@@ -41,7 +41,7 @@ function useResizeDetector(props: Props = {}): returnType {
     }
   }, [skipOnMount]);
 
-  const [size, setSize] = useState({
+  const [size, setSize] = useState<ReactResizeDetectorDimensions>({
     width: undefined,
     height: undefined
   });
@@ -72,7 +72,7 @@ function useResizeDetector(props: Props = {}): returnType {
 
     const resizeObserver = new window.ResizeObserver(resizeHandler.current);
     if (ref.current) {
-      resizeObserver.observe(ref.current);
+      resizeObserver.observe(ref.current as Element);
     }
 
     return () => {


### PR DESCRIPTION
### Part 1: useResizeDetector fixes

I experienced the same issue as @stefann01: https://github.com/maslianok/react-resize-detector/issues/108#issuecomment-760239999

This pull request fixes that issue by changing `MutableRefObject<undefined | Element>` to `MutableRefObject<null | Element>`, because the `ref` prop on a `div` expects a `RefObject<null | HTMLDivElement>`.  Also allows an optional dynamic type element `RefType`, so that the hook can be used as so:
```
const { width, height, ref } = useResizeDetector<HTMLDivElement>();
```
This allows for the ref to be passed to a `<div />` more easily in typescript and allows developers to use other `HTMLDivElement`-specific properties on the ref.

### Part 2: ResizeDetector fixes

I noticed a type discrepancy in the main ResizeDetector component that prevented its use in my strictly-typed application. As you'll see in the changes, I updated the type to that what was actually passed to the child function is what was declared in the props that would be passed.

I tested these changes on my own project and it resolves the typescript issues and appears to behave the same.