### PR TITLE
Fix redundant set state in useResizeDetector

### DIFF
--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -10,13 +10,22 @@ interface returnType<RefType> extends ReactResizeDetectorDimensions {
   ref: MutableRefObject<null | RefType>
 }
 
-const createAsyncNotifier = (onResize: Props['onResize'], setSize: (size: ReactResizeDetectorDimensions) => void) =>
+const createAsyncNotifier = (
+  onResize: Props['onResize'],
+  setSize: React.Dispatch<React.SetStateAction<ReactResizeDetectorDimensions>>
+) =>
   rafSchd(({ width, height }) => {
     if (onResize && isFunction(onResize)) {
       onResize(width, height);
     }
 
-    setSize({ width, height });
+    setSize(prev => {
+      if (prev.width === width && prev.height === height) {
+        return prev;
+      } else {
+        return { width, height };
+      }
+    });
   });
 
 function useResizeDetector<RefType extends Element = Element>(props: Props = {}): returnType<RefType> {

--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -22,9 +22,8 @@ const createAsyncNotifier = (
     setSize(prev => {
       if (prev.width === width && prev.height === height) {
         return prev;
-      } else {
-        return { width, height };
       }
+      return { width, height };
     });
   });
 


### PR DESCRIPTION
When you call `setState` with an object that is _deeply equal_ to the current state you trigger a render even though the state has not changed.

The current useResizeDetector renders the component it is attached to at the `refreshRate`. This is not good for performance.

In order to fix the issue we should not change the size state unnecessarily.
I changed the `setSize` call in the `createAsyncNotifier` to check the current width and height.
If the width and height are the same we return the current state.
We only update the state if the width and height change.

I also had to change the `setSize` type definition to enable using the function form of `setState`.

See [this link](https://medium.com/welldone-software/track-redundant-re-renders-that-caused-by-hooks-with-why-did-you-render-version-3-504468deb653) for more information about redundant rerenders caused by hooks.

