### PR TITLE
useResizeDetector updating internally on DOM/ref changes

### DIFF
--- a/src/ResizeDetector.tsx
+++ b/src/ResizeDetector.tsx
@@ -25,7 +25,7 @@ export interface Props {
    * Function that will be invoked with observable element's width and height.
    * Default: undefined
    */
-  onResize?: (width?: number, height?: number) => void;
+  onResize?: (width?: number, height?: number, refNode?: null|Element) => void;
   /**
    * Trigger update on height change.
    * Default: true

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,8 @@ export const createNotifier = (
   onResize: Props['onResize'],
   setSize: React.Dispatch<React.SetStateAction<ReactResizeDetectorDimensions>>,
   handleWidth: boolean,
-  handleHeight: boolean
+  handleHeight: boolean,
+  refNode?: Element | null | undefined,
 ) => ({ width, height }: ReactResizeDetectorDimensions): void => {
   setSize(prev => {
     if (prev.width === width && prev.height === height) {
@@ -45,7 +46,7 @@ export const createNotifier = (
     }
 
     if (onResize && isFunction(onResize)) {
-      onResize(width, height);
+      onResize(width, height, refNode);
     }
 
     return { width, height };


### PR DESCRIPTION
The current useResizeDetector does not update on DOM/ref changes of the component it is attached to.
Reproduce: [demo](https://codesandbox.io/s/material-demo-forked-iyng4?file=/demo.js)
This pr also adds the dom node it is attached to to the onResize callback.

Resources: [res1](https://github.com/facebook/react/blob/bbb2ba8c8db747d70f5ef4114051e69aa5950b60/packages/react/src/ReactHooks.js#L107)
[res2](https://github.com/theKashey/use-callback-ref#useref-api)