### PR TITLE
fix: polyfill usage

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,7 @@ const getConfig = withPolyfill => ({
     : [getOutput(packageJson.main, 'cjs'), getOutput(packageJson.module, 'esm')],
   external: externalDeps,
   plugins: [resolve(), commonjs(), typescript({ useTsconfigDeclarationDir: true })].concat(
-    withPolyfill ? [inject({ ResizeObserver: 'resize-observer-polyfill' })] : []
+    withPolyfill ? [inject({ 'window.ResizeObserver': 'resize-observer-polyfill' })] : []
   )
 });
 


### PR DESCRIPTION
`ResizeObserver` and `window.ResizeObserver` are different constants from `rollup-plugin-inject` parser point of view.

It should either `ResizeObserver` in the code or `window.ResizeObserver` in `rollup-plugin-inject` replacements.