### PR TITLE
Use useEffect for SSR, add ref.current to dependency array

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const CustomComponent = () => {
 import { useResizeDetector } from 'react-resize-detector';
 
 const CustomComponent = () => {
-  const targetRef = userRef();
+  const targetRef = useRef();
   const { width, height } = useResizeDetector({ targetRef });
   return <div ref={targetRef}>{`${width}x${height}`}</div>;
 };

--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -1,8 +1,10 @@
-import { useLayoutEffect, useState, useRef, MutableRefObject } from 'react';
+import { useLayoutEffect, useEffect, useState, useRef, MutableRefObject } from 'react';
 
 import { patchResizeHandler, createNotifier, isSSR, patchResizeHandlerType } from './utils';
 
 import { Props, ReactResizeDetectorDimensions } from './ResizeDetector';
+
+const useEnhancedEffect = isSSR() ? useEffect: useLayoutEffect;
 
 type resizeHandlerType = MutableRefObject<null | patchResizeHandlerType>;
 interface returnType<RefType> extends ReactResizeDetectorDimensions {
@@ -36,7 +38,7 @@ function useResizeDetector<RefType extends Element = Element>(props: FunctionPro
     height: undefined
   });
 
-  useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     if (isSSR()) {
       return;
     }
@@ -73,7 +75,7 @@ function useResizeDetector<RefType extends Element = Element>(props: FunctionPro
         patchedResizeHandler.cancel();
       }
     };
-  }, [refreshMode, refreshRate, refreshOptions, handleWidth, handleHeight, onResize, observerOptions]);
+  }, [refreshMode, refreshRate, refreshOptions, handleWidth, handleHeight, onResize, observerOptions, ref.current]);
 
   return { ref, ...size };
 }


### PR DESCRIPTION
Relates to #130 and  #138 

fix for #138 borrowed [from](https://github.com/mui-org/material-ui/blob/2c8721ccf11740589c975eec46775f3a3ede830d/packages/material-ui/src/utils/useEventCallback.js#L3) (MIT-License)

Resources for #138: [res1](https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a) and maybe [res2](https://youtu.be/TQQPAU21ZUw)
