### PR TITLE
Fixed the behavior that the ref type is fixed to null

### DIFF
--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -25,7 +25,7 @@ function useResizeDetector(props: FunctionProps = {}) {
 
   const skipResize: MutableRefObject<null | boolean> = useRef(skipOnMount);
   const localRef = useRef(null);
-  const ref = (targetRef ?? localRef) as MutableRefObject<null>;
+  const ref = (targetRef ?? localRef) as MutableRefObject<null | Element>;
   const resizeHandler = useRef<ResizeObserverCallback>();
 
   const [size, setSize] = useState<ReactResizeDetectorDimensions>({


### PR DESCRIPTION
Since v6.6.3,   
the type definition of ref returned by useResizeDetector has been changed from `MutableRefObject <null | Element>` to `MutableRefObject <null>` .

## before  `build/useResizeDetector.d.ts`
```typescript
import { MutableRefObject } from 'react';
import { Props, ReactResizeDetectorDimensions } from './ResizeDetector';
interface returnType<RefType> extends ReactResizeDetectorDimensions {
    ref: MutableRefObject<null | RefType>;
}
interface FunctionProps<RefType> extends Props {
    targetRef?: MutableRefObject<null | RefType>;
}
declare function useResizeDetector<RefType extends Element = Element>(props?: FunctionProps<RefType>): returnType<RefType>;
export default useResizeDetector;
```

## after   `build/useResizeDetector.d.ts`
```typescript
import { useRef, MutableRefObject } from 'react';
import { Props } from './ResizeDetector';
interface FunctionProps extends Props {
    targetRef?: ReturnType<typeof useRef>;
}
declare function useResizeDetector(props?: FunctionProps): {
    height?: number | undefined;
    width?: number | undefined;
    ref: MutableRefObject<null>;
};
export default useResizeDetector;
```

Here are the changes that cause it.
https://github.com/maslianok/react-resize-detector/commit/7f1fc988a7eeaec3a22e4e20bde0afcbda6ad404#diff-045dde5368069c113c4ac044407e3cba3f7cc3db1c6f0e166514b1cc9f5cf28fL33

Due to this behavior change, the follo
wing TS error will appear in the logic using the ref acquired on the application.
`TS2345: Argument of type 'null' is not assignable to parameter of type 'Element'`
```typescript
useEffect(() => {
    if (divRef.current) {
        // Will contain Element...
        createModalWithElement(divRef.current);
    }
}, [someValue])
```
This PR is intended to undo its type definition.
I'm sorry if the correction is incorrect.

This package is very convenient, thank you!