### PR TITLE
Fix ref type

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -46,7 +46,7 @@ type MainFramePropsType = {
 // #### 1. React hook (new in v6.0.0)
 const MainFrame = ({ onHideLeftPanel }: MainFramePropsType) => {
   const [count, setCount] = useState(0);
-  const { width, height, ref } = useResizeDetector();
+  const { width, height, ref } = useResizeDetector<HTMLDivElement>();
   // { refreshMode: 'debounce', refreshRate: 2000, skipOnMount: true }
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^16.0.0 || ^17.0.0"
   },
   "author": "Vitalii Maslianok <maslianok@gmail.com> (https://github.com/maslianok)",
-  "version": "6.6.5",
+  "version": "6.7.0-rc.0",
   "bugs": {
     "url": "https://github.com/maslianok/react-resize-detector/issues"
   },

--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -10,7 +10,7 @@ interface FunctionProps extends Props {
   targetRef?: ReturnType<typeof useRef>;
 }
 
-function useResizeDetector(props: FunctionProps = {}) {
+function useResizeDetector<T = any>(props: FunctionProps = {}) {
   const {
     skipOnMount = false,
     refreshMode,
@@ -25,7 +25,7 @@ function useResizeDetector(props: FunctionProps = {}) {
 
   const skipResize: MutableRefObject<null | boolean> = useRef(skipOnMount);
   const localRef = useRef(null);
-  const ref = (targetRef ?? localRef) as MutableRefObject<null | Element>;
+  const ref = (targetRef ?? localRef) as MutableRefObject<T>;
   const resizeHandler = useRef<ResizeObserverCallback>();
 
   const [size, setSize] = useState<ReactResizeDetectorDimensions>({


### PR DESCRIPTION
Defaults to `any`

```jsx
const { width, height, ref } = useResizeDetector();

<div ref={ref}>  // ref: React.MutableRefObject<any>
```

With typings

```jsx
const { width, height, ref } = useResizeDetector<HTMLDivElement>();

<div ref={ref}>  // ref: React.MutableRefObject<HTMLDivElement>
```