### PR TITLE
Add measureDuringRender option to useResizeDetector; improve typings

### DIFF
--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -1,16 +1,29 @@
 import { useLayoutEffect, useEffect, useState, useRef, MutableRefObject } from 'react';
 
-import { patchResizeHandler, createNotifier, isSSR } from './utils';
+import {
+  patchResizeHandler,
+  createNotifier,
+  isSSR,
+  patchResizeHandlerType
+} from './utils';
 
 import { Props, ReactResizeDetectorDimensions } from './ResizeDetector';
 
-const useEnhancedEffect = isSSR() ? useEffect : useLayoutEffect;
-
 interface FunctionProps extends Props {
   targetRef?: ReturnType<typeof useRef>;
+
+  /**
+   * Whether to allow measuring during the render cycle. While measuring
+   * during the render cycle allows for the size to be used in the first
+   * render, it could cause a "Cannot update a component while rendering a
+   * different component" error if passed via a callback to a component that
+   * then calls `setState` with it.
+   * Default: true
+   */
+  measureDuringRender?: boolean;
 }
 
-function useResizeDetector<T = any>(props: FunctionProps = {}) {
+function useResizeDetector<T extends Element = any>(props: FunctionProps = {}) {
   const {
     skipOnMount = false,
     refreshMode,
@@ -18,6 +31,7 @@ function useResizeDetector<T = any>(props: FunctionProps = {}) {
     refreshOptions,
     handleWidth = true,
     handleHeight = true,
+    measureDuringRender = true,
     targetRef,
     observerOptions,
     onResize
@@ -26,12 +40,15 @@ function useResizeDetector<T = any>(props: FunctionProps = {}) {
   const skipResize: MutableRefObject<null | boolean> = useRef(skipOnMount);
   const localRef = useRef(null);
   const ref = (targetRef ?? localRef) as MutableRefObject<T | null>;
-  const resizeHandler = useRef<ResizeObserverCallback>();
+  const resizeHandler = useRef<patchResizeHandlerType>();
 
   const [size, setSize] = useState<ReactResizeDetectorDimensions>({
     width: undefined,
     height: undefined
   });
+
+  const useEnhancedEffect =
+    isSSR() || !measureDuringRender ? useEffect : useLayoutEffect;
 
   useEnhancedEffect(() => {
     if (isSSR()) {
@@ -60,14 +77,13 @@ function useResizeDetector<T = any>(props: FunctionProps = {}) {
     const resizeObserver = new window.ResizeObserver(resizeHandler.current as ResizeObserverCallback);
 
     if (ref.current) {
-      // Something wrong with typings here...
-      resizeObserver.observe(ref.current as any, observerOptions);
+      resizeObserver.observe(ref.current, observerOptions);
     }
 
     return () => {
       resizeObserver.disconnect();
-      const patchedResizeHandler = resizeHandler.current as any;
-      if (patchedResizeHandler && patchedResizeHandler.cancel) {
+      const patchedResizeHandler = resizeHandler.current;
+      if (patchedResizeHandler && 'cancel' in patchedResizeHandler) {
         patchedResizeHandler.cancel();
       }
     };

--- a/src/useResizeDetector.ts
+++ b/src/useResizeDetector.ts
@@ -1,11 +1,6 @@
 import { useLayoutEffect, useEffect, useState, useRef, MutableRefObject } from 'react';
 
-import {
-  patchResizeHandler,
-  createNotifier,
-  isSSR,
-  patchResizeHandlerType
-} from './utils';
+import { patchResizeHandler, createNotifier, isSSR, patchResizeHandlerType } from './utils';
 
 import { Props, ReactResizeDetectorDimensions } from './ResizeDetector';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "jsx": "react",
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": false,
+    // Needed for lodash imports
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitAny": false,
     "skipLibCheck": true


### PR DESCRIPTION
## Motivation

When using `useResizeDetector`, I noticed that I got errors when I tried to call `setState` on another component with the results of the `onResize` in a single component

```
import React, { PropsWithChildren, useRef, useState } from 'react';
import { useResizeDetector } from 'react-resize-detector/build/withPolyfill';

function OuterComponent() {
  const [innerWidth, setInnerWidth] = useState<number | null>(null);
  return (
    <>
      <div>Inner width: {innerWidth}</div>
      <InnerComponent
        onResize={(width) => {
          if (width !== undefined) setInnerWidth(width);
        }}
      />
    </>
  );
}

interface InnerProps {
  onResize: (width?: number, height?: number) => unknown;
}

function InnerComponent(props: PropsWithChildren<InnerProps>) {
  const { onResize } = props;
  const divRef = useRef<HTMLDivElement>(null);
  useResizeDetector({ targetRef: divRef, onResize });

  return <div ref={divRef}>Hello</div>;
}
```

Trying to render OuterComponent above would cause an error: "Cannot update a component while rendering a different component".

This is because the `onResize` callback is initially called when the ResizeObserver is attached within a call to `useLayoutEffect`, which runs during the rendering cycle of the component that calls `useResizeDetector`.

## Fix

- Add an option allowing `useResizeDetector` to be only initialized in a `useEffect` instead of `useLayoutEffect` block
- Cleaned up a bit of Typescript typings

## Testing

Tested the above code with the new `measureDuringRender` option set to false. It runs without an error!