### PR TITLE
Remove dependency on resize-observer-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "@types/resize-observer-browser": "^0.1.6",
     "lodash.debounce": "^4.0.8",
-    "lodash.throttle": "^4.1.1",
-    "resize-observer-polyfill": "^1.5.1"
+    "lodash.throttle": "^4.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",


### PR DESCRIPTION
> Handle element resizes like it's 2021!

In 2021, it's already been 1-3 years since major browsers started supporting ResizeObserver natively. Users who haven't updated their browser for that long are in trouble anyway. Application developers who still want to support such users, can just add back the dependency. The latest version of the polyfill has broken types (https://github.com/que-etc/resize-observer-polyfill/issues/83), so it's a hassle to deal with.

This requries a major version release.