### PR TITLE
Move @type to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "prerelease": "npm version prerelease --preid=rc"
   },
   "dependencies": {
-    "@types/resize-observer-browser": "^0.1.6",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
@@ -30,6 +29,7 @@
     "@types/lodash": "^4.14.178",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
+    "@types/resize-observer-browser": "^0.1.6",
     "@typescript-eslint/eslint-plugin": "^5.8.0",
     "@typescript-eslint/parser": "^5.8.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
`@type`'s should remain in dev dependencies. My multi repo project throws `Cannot find name 'DOMRectReadOnly'` because those packages aren't using `"lib": ["DOM"]` in their `tsconfig.json`.