### PR TITLE
Set observable element to null while unmounting component

### DIFF
--- a/src/ResizeDetector.tsx
+++ b/src/ResizeDetector.tsx
@@ -146,6 +146,7 @@ class ResizeDetector<ElementT extends HTMLElement = HTMLElement> extends PureCom
     if (isSSR()) {
       return;
     }
+    this.observableElement = null;
     this.resizeObserver.disconnect();
     this.cancelHandler();
   }


### PR DESCRIPTION
This will resolve bug described in #208 

The problem came out because React in version 18 is unmounting and remounting elements