### PR TITLE
[228] Fix SourceMaps generation

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -8,6 +8,7 @@ import packageJson from './package.json' assert { type: 'json' };
 const getOutput = (path, format) => ({
   file: path,
   format: format,
+  sourcemap: true,
   compact: true,
   exports: 'named'
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "inlineSources": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build", "src/**/*.test.tsx"]


### PR DESCRIPTION
Refs #228 

## Changelog:
- Turn on `sourcemap` generation in the `rollup.config.mjs`
- Turn on the `inlineSources` param in the `tsconfig.json` file