### PR TITLE
remove duplicate imports

### DIFF
--- a/src/ResizeDetector.tsx
+++ b/src/ResizeDetector.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { PureComponent, isValidElement, cloneElement, createRef, ReactNode, ReactElement, RefObject } from 'react';
+import React, { PureComponent, isValidElement, cloneElement, createRef, ReactNode, ReactElement, RefObject } from 'react';
 import { findDOMNode } from 'react-dom';
 
 import { patchResizeHandler, isFunction, isSSR, isDOMElement, createNotifier } from './utils';

--- a/src/withResizeDetector.tsx
+++ b/src/withResizeDetector.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { Component, createRef, forwardRef, ComponentType, ForwardedRef, MutableRefObject } from 'react';
+import React, { Component, createRef, forwardRef, ComponentType, ForwardedRef, MutableRefObject } from 'react';
 
 import ResizeDetector, { ResizeDetectorProps } from './ResizeDetector';
 


### PR DESCRIPTION
We've seen some issues on our project indicating that this repo has duplicate `React` declarations. For instance, we're seeing this error:

```
[commonjs--resolver] Identifier 'React' has already been declared (2:10) in /usr/src/app/node_modules/react-resize-detector/build/index.esm.js
file: /usr/src/app/node_modules/react-resize-detector/build/index.esm.js:2:10
1: import*as React from'react';import {cloneElement,isValidElement,createRef,PureComponent,Component,forwardRef,useRef,useState,useEffect,useLayoutEffect}from'react';import {findDOMNode}from'react-dom';/******************************************************************************
2: Copyright (c) Microsoft Corporation.
```

I confirmed that these changes fix the above error and still functions as intended.