### PR TITLE
Issue #237 - Do not call onResize during setSize updater function in createNotifier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import ResizeDetector from './ResizeDetector';
 import withResizeDetector from './withResizeDetector';
-import useResizeDetector, { UseResizeDetectorReturn } from './useResizeDetector';
+import useResizeDetector from './useResizeDetector';
 
-export { withResizeDetector, useResizeDetector, UseResizeDetectorReturn };
+export { withResizeDetector, useResizeDetector };
 
-export type { ResizeDetectorProps } from './types';
-export type { useResizeDetectorProps } from './useResizeDetector';
+export type { ResizeDetectorProps, UseResizeDetectorReturn, useResizeDetectorProps } from './types';
 
 export default ResizeDetector;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,22 +31,27 @@ export const isDOMElement = (element: unknown): boolean =>
 
 export const createNotifier =
   (
+    onResize: Props['onResize'],
+    sizeRef: Readonly<React.MutableRefObject<ReactResizeDetectorDimensions>>,
     setSize: React.Dispatch<React.SetStateAction<ReactResizeDetectorDimensions>>,
     handleWidth: boolean,
     handleHeight: boolean
   ) =>
   ({ width, height }: ReactResizeDetectorDimensions): void => {
-    setSize(prev => {
-      if (prev.width === width && prev.height === height) {
-        // skip if dimensions haven't changed
-        return prev;
-      }
+    const { current: prev } = sizeRef;
 
-      if ((prev.width === width && !handleHeight) || (prev.height === height && !handleWidth)) {
-        // process `handleHeight/handleWidth` props
-        return prev;
-      }
+    if (prev.width === width && prev.height === height) {
+      // skip if dimensions haven't changed
+      return;
+    }
 
-      return { width, height };
-    });
+    if ((prev.width === width && !handleHeight) || (prev.height === height && !handleWidth)) {
+      // process `handleHeight/handleWidth` props
+      return;
+    }
+
+    onResize?.(width, height);
+
+    const newSize = { width, height };
+    setSize(newSize);
   };


### PR DESCRIPTION
Updated `createNotifier` to conditionally call `setSize` based on the current `size`. Also reference my comment here: https://github.com/maslianok/react-resize-detector/issues/237#issuecomment-1489031131

Things work okay in the local example, and I didn't see any unit tests, but I'm happy to do any specific testing that you guys need.