### PR TITLE
security: bump lodash from ^4.17.21 to ^4.18.0 to fix CVE-2025-13465 and CVE-2026-2950

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@types/resize-observer-browser": "^0.1.6",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2477,6 +2477,11 @@ lodash@^4.17.13, lodash@^4.17.19, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
 loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"


### PR DESCRIPTION
## Maintainer Action Required

This is a **security backport PR** targeting `v6.7.8`, not `master`.

Since Git tags do not exist for `v6.7.7` and `v6.7.8` in this repository, 
and PRs cannot be raised directly against a commit or npm release, could a 
maintainer please:

1. Create a branch off commit `9918fbd` (the commit published as `v6.7.8` on npm):
```bash
   git checkout 9918fbd
   git checkout -b release/6.7.x
   git push origin release/6.7.x
```
2. Retarget this PR from `your-fork:release/6.7.x` → `upstream:release/6.7.x`

This is intentionally **not** raised against `master` because the fix is 
specifically for users pinned to `v6.7.x` who cannot upgrade to a newer 
major version.

---


## Summary

This PR updates the `lodash` dependency from `^4.17.21` to `^4.18.0` to address 
two prototype pollution vulnerabilities affecting the current version.

---

## Vulnerabilities Fixed

### CVE-2025-13465 — Prototype Pollution in `_.unset` and `_.omit`
- **Severity:** Medium (CVSS 6.5)
- **Affected versions:** lodash 4.0.0 through 4.17.22
- **Fixed in:** lodash 4.17.23
- **Description:** An attacker can pass crafted paths to `_.unset` and `_.omit` 
  causing deletion of methods from global prototypes.

### CVE-2026-2950 — Bypass of CVE-2025-13465 fix via array-wrapped path segments
- **Severity:** Medium (CVSS 6.5)
- **Affected versions:** lodash 4.17.23 and earlier
- **Fixed in:** lodash 4.18.0
- **Description:** The fix for CVE-2025-13465 only guarded against string key 
  members. An attacker can bypass it by passing array-wrapped path segments, 
  allowing deletion of properties from built-in prototypes such as 
  `Object.prototype`, `Number.prototype`, and `String.prototype`.

---

## Changes

- `package.json`: `"lodash": "^4.17.21"` → `"lodash": "^4.18.0"`
- `yarn-lock.json`: updated resolved lodash version

No source code changes were required. `@types/lodash` is unaffected as it 
contains type definitions only and has no runtime impact.

---

## Base Commit

This PR is branched from commit `9918fbd`, which corresponds to the version 
published as `v6.7.8` on npm. No Git tag exists for this version in the 
repository.

---

## References

- [CVE-2025-13465](https://www.cvedetails.com/cve/CVE-2025-13465/)
- [CVE-2026-2950](https://www.cvedetails.com/cve/CVE-2026-2950/)
- [lodash security advisory](https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg)